### PR TITLE
writeEvent uses `cat(..., append = TRUE)` not a file connection

### DIFF
--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -153,7 +153,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
       private$localHost <- host
       private$localPort <- port
       private$outputFileName <- outputFileName
-      private$outputFile <- file(outputFileName, "w")
+      cat("", file = private$outputFileName, append = FALSE)
       private$sessionCookies <- sessionCookies
       private$startServer()
     },
@@ -163,7 +163,6 @@ RecordingSession <- R6::R6Class("RecordingSession",
         httpuv::stopServer(private$localServer)
         httpuv::interrupt()
         private$localServer <- NULL
-        close(private$outputFile)
       }
     },
     # An environment of session-specific identifier strings to their
@@ -176,13 +175,15 @@ RecordingSession <- R6::R6Class("RecordingSession",
     localPort = NULL,
     localServer = NULL,
     outputFileName = NULL,
-    outputFile = NULL,
     sessionCookies = data.frame(),
     clientWsState = NULL,
     postCounter = 0,
     writeEvent = function(evt) {
-      writeLines(format(evt), private$outputFile)
-      flush(private$outputFile)
+      cat(
+        format(evt), "\n",
+        file = private$outputFileName,
+        append = TRUE
+      )
     },
     mergeCookies = function(handle) {
       df <- curl::handle_cookies(handle)[,c("name", "value")]


### PR DESCRIPTION
This stops the error "invalid connection".

File connections should be closed properly otherwise a warning appears at a later time.

It makes sense to close the file in the `stop` method.  However once it finishes, other close events are fired after the 'tick'.  This prevents other writeEvent calls from being fired as the writing to file has been closed.

By using `cat(..., append = TRUE)` we do not need to carry a file connection and it will always append to the existing log file until the next recorder initialization where `append = FALSE`.