### PR TITLE
Exit early if attempt made to record shinyapps.io app

### DIFF
--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -151,6 +151,9 @@ RecordingSession <- R6::R6Class("RecordingSession",
   public = list(
     initialize = function(targetAppUrl, host, port, outputFileName, sessionCookies) {
       private$targetURL <- URLBuilder$new(targetAppUrl)
+      if (grepl("shinyapps.io$", private$targetURL$host)) {
+        stop("Recording shinyapps.io apps is not supported")
+      }
       private$localHost <- host
       private$localPort <- port
       private$outputFileName <- outputFileName


### PR DESCRIPTION
Example effect:
```
> shinyloadtest::record_session("https://gallery.shinyapps.io/012-datatables/", output_file = "/tmp/dt.log")

 Error in .subset2(public_bind_env, "initialize")(...) : 
  Recording shinyapps.io apps is not supported 
```