### PR TITLE
DT support

### DIFF
--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -328,13 +328,15 @@ RecordingSession <- R6::R6Class("RecordingSession",
           # so we must detect it here and replace it with the placeholder
           # whenever we see it next.
           df <- tree_df(parsed)
-          urls <- subset(df, df[,5] == "ajax" & df[,6] == "url")[,7]
-          if (length(urls) > 0) {
-            url <- urls[[1]]
-            match <- stringr::str_match(url, "nonce=(\\w+)")
-            if (!is.na(match[[1]])) {
-              self$tokens[[match[[2]]]] <- "${NONCE}"
-            } else stop("Expected an ajax URL containing a nonce")
+          if (ncol(df) >= 7) {
+            urls <- subset(df, df[,5] == "ajax" & df[,6] == "url")[,7]
+            if (length(urls) > 0) {
+              url <- urls[[1]]
+              match <- stringr::str_match(url, "nonce=(\\w+)")
+              if (!is.na(match[[1]])) {
+                self$tokens[[match[[2]]]] <- "${NONCE}"
+              } else stop("Expected an ajax URL containing a nonce")
+            }
           }
 
         # Every other websocket event

--- a/R/util.R
+++ b/R/util.R
@@ -17,9 +17,9 @@ as_entries <- function(named_list) {
 # Returns a list of lists, each a path into the nested structure x. Each path
 # ends with the value at the leaf.
 paths <- function(parent, x) {
-  if (rlang::is_list(x)) {
+  if (typeof(x) == "list") {
     # Named list aka JSON object
-    if (rlang::is_named(x)) {
+    if (!is.null(names(x))) {
       Mapcan(function(entry) {
         paths(c(parent, entry$key), entry$val)
       }, as_entries(x))

--- a/R/util.R
+++ b/R/util.R
@@ -4,3 +4,48 @@
   else
     x
 }
+
+# Like Map but expects f to return a list and concatenates results.
+Mapcan <- function(f, xs) Reduce(append, Map(f, xs))
+
+# Returns a list of named lists, each with `name` and `value` values, for the
+# given named list.
+as_entries <- function(named_list) {
+  Map(function(name) list(key = name, val = named_list[[name]]), names(named_list))
+}
+
+# Returns a list of lists, each a path into the nested structure x. Each path
+# ends with the value at the leaf.
+paths <- function(parent, x) {
+  if (rlang::is_list(x)) {
+    # Named list aka JSON object
+    if (rlang::is_named(x)) {
+      Mapcan(function(entry) {
+        paths(c(parent, entry$key), entry$val)
+      }, as_entries(x))
+    # Unnamed list aka JSON array
+    } else if (length(x) > 0) {
+      Mapcan(function(i) {
+        paths(c(parent, i), x[[i]])
+      }, 1:length(x))
+    }
+  } else {
+    # Leaf, so return the path here + the leaf value
+    list(c(parent, x))
+  }
+}
+
+# Returns a data frame where each row is a distinct path into a tree of lists,
+# such as that produced by jsonlite::fromJSON. Useful for querying deeply-nested
+# structures in a tabular fashion.
+tree_df <- function(tree) {
+  ps <- paths(list(), tree)
+
+  # Ensure rows are all the same length, with NA for padding
+  longest <- max(unlist(Map(length, ps)))
+  padded <- Map(function(path) {
+    c(as.list(path), rep(NA, longest-length(path)))
+  }, ps)
+
+  do.call(rbind, padded)
+}


### PR DESCRIPTION
The funky thing about DT is that it works by sending Ajax POST requests to the app instead of by sending websocket messages.

This wouldn't be a problem since we acquired POST support, were it not for the fact that the URL DT posts to contains a new kind of session-specific identifier, the "nonce". The nonce is embedded in a URL the client receives via websocket right after the app loads. The URL part of the message looks something like this: `"session/${SESSION}/dataobj/mytable1?w=&nonce=cde5e133bc1937e8"`

<details><summary>Full WS_RECV message containing initial appearance of nonce</summary>

```
{"type":"WS_RECV","begin":"2018-06-27T23:0207.070Z","message":"{\"errors\":[],\"
values\":{\"mytable1\":{\"x\":{\"filter\":\"none\",\"container\":\"<table 
class=\\\"display\\\">\\n  <thead>\\n    <tr>\\n      <th> <\\/th>\\n      
<th>carat<\\/th>\\n      <th>cut<\\/th>\\n      <th>color<\\/th>\\n      
<th>clarity<\\/th>\\n      <th>depth<\\/th>\\n      <th>table<\\/th>\\n      
<th>price<\\/th>\\n      <th>x<\\/th>\\n      <th>y<\\/th>\\n      
<th>z<\\/th>\\n    <\\/tr>\\n  
<\\/thead>\\n<\\/table>\",\"options\":{\"columnDefs\":[{\"className\":\"dt-right
\",\"targets\":[1,5,6,7,8,9,10]},{\"orderable\":false,\"targets\":0}],\"order\":
[],\"autoWidth\":false,\"orderClasses\":false,\"ajax\":{\"url\":\"session/${SESS
ION}/dataobj/mytable1?w=&nonce=cde5e133bc1937e8\",\"type\":\"POST\",\"data\":\"f
unction(d) {\\nd.search.caseInsensitive = true;\\nd.search.smart = 
true;\\nd.escape = true;\\nvar encodeAmp = function(x) { x.value = 
x.value.replace(/&/g, \\\"%26\\\"); 
}\\nencodeAmp(d.search);\\n$.each(d.columns, function(i, v) 
{encodeAmp(v.search);});\\n}\"},\"serverSide\":true,\"processing\":true},\"selec
tion\":{\"mode\":\"multiple\",\"selected\":null,\"target\":\"row\"}},\"evals\":[
\"options.ajax.data\"],\"jsHooks\":[],\"deps\":[{\"name\":\"dt-core\",\"version\
":\"1.10.16\",\"src\":{\"href\":\"dt-core-1.10.16\"},\"meta\":null,\"script\":\"
js/jquery.dataTables.min.js\",\"stylesheet\":[\"css/jquery.dataTables.min.css\",
\"css/jquery.dataTables.extra.css\"],\"head\":null,\"attachment\":null,\"package
\":null,\"all_files\":false},{\"name\":\"jquery\",\"version\":\"1.11.3\",\"src\"
:{\"href\":\"jquery-1.11.3\"},\"meta\":null,\"script\":\"jquery.min.js\",\"style
sheet\":null,\"head\":null,\"attachment\":null,\"package\":null,\"all_files\":tr
ue},{\"name\":\"crosstalk\",\"version\":\"1.0.0\",\"src\":{\"href\":\"crosstalk-
1.0.0\"},\"meta\":null,\"script\":\"js/crosstalk.min.js\",\"stylesheet\":\"css/c
rosstalk.css\",\"head\":null,\"attachment\":null,\"package\":null,\"all_files\":
true}]}},\"inputMessages\":[]}"}
```

</details>
</br>

Without finding and replacing the nonce in subsequent requests, we end up with DT traffic in the recording that looks like this:

```
{"type":"REQ_POST","begin":"2018-06-27T23:0207.154Z","end":"2018-06-27T23:0207.1
67Z","status":200,"url":"/session/${SESSION}/dataobj/mytable1?w=&nonce=cde5e133b
c1937e8","datafile":"/tmp/dev-dt.log.post.0"}
```

So, we need to add logic to the place where we interpret WS messages from the server that recognizes the message containing the initial nonce, parses it out, and stores it as the placeholder `${NONCE}` so that it can be replaced in all subsequent requests and URLs.

One question you might have is, why not ignore this WS message, and instead recognize the nonces in the REQ_POST area of the code? A reason not to do that is that shinycannon compares messages it expects with messages it receives, and so even if we punted in shinyloadtest we'd need to add case-specific pseudo-equivalence check in the relevant area of shinycannon. We also don't want to just discard this message, because as a WS message coming from R it represents potentially interesting timing data.

Recognizing the kind of message we need to dig the URL out of isn't especially easy, because it's a JSON object with significant nesting that contains arbitrary intermediate keys (the user-provided names of their DT inputs). So, the object can't be navigated by digging out well-known keys like we were able to do with `WS_RECV_INIT` and `WS_RECV_BEGIN_UPLOAD`.

To make querying the object easier I added a function, `tree_df`, that produces a data frame of paths into the object. Instead of special-case tree-walking logic, the detection of the nonce-containing object can happen with a partial structural query like this: `subset(df, df[,5] == "ajax" & df[,6] == "url")[,7]`. This means something like, produce the values at depth 7 where the values at depths 5 and 6 are "ajax" and "url", respectively.

I was worried that building these DFs would make apps feel slower (the DF building happens on receipt of every websocket message) but with some casual testing it doesn't seem to.

With a typical value of `msg`, the added overhead is only about 1.5ms:

```
> microbenchmark(tree_df(msg))
Unit: milliseconds
         expr      min      lq     mean   median       uq      max neval
 tree_df(msg) 1.155867 1.42866 1.489742 1.443248 1.478908 3.468009   100
```

## Dev tasks

- [x] First cut
- [ ] Support multiple nonce appearances per WS_RECV - this happens when multiple DTs appear at the same time
- [ ] Make a `WS_RECV_DT_INIT` type message that adds a `paths` field that's an array of path arrays. Each path array is the path in the JSON to a URL containing a nonce that must be detected/substituted. This allows shinycannon to be dumber.