### PR TITLE
Fix timestamp format and datafile name

### DIFF
--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -33,7 +33,7 @@ resp_httr_to_rook <- function(resp) {
 }
 
 makeTimestamp <- function(time = Sys.time()) {
-  format(time, "%Y-%m-%dT%H:%M%%OS3Z", tz = "UTC")
+  format(time, "%Y-%m-%dT%H:%M:%%OS3Z", tz = "UTC")
 }
 
 # Returns NA if workerid not found. This either indicates an error state of some
@@ -251,7 +251,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
       )
 
       if (!is.null(dataFileName)) {
-        event$datafile <- dataFileName
+        event$datafile <- basename(dataFileName)
       }
 
       private$writeEvent(structure(event, class = "REQ"))


### PR DESCRIPTION
This fixes two problems with recording output:

* The lack of a `:` between minutes and seconds in the timestamp makes the timestamp an invalid ISO date/time stamp, and so extra parsing hoops are required in `shinycannon` without this fix.
* The `datafile` field of `REQ_POST` records contained the full path to the datafile, which we don't want, because we want the path of data files to be relative to the recording. So instead of `datafile: "/tmp/foo.log.post.0"` we want `datafile: "foo.log.post.0"`

Once this is merged I will modify the recordings that @shalutiwari attached to https://trello.com/c/Q5kRB9u9 before she left so that she won't have to re-do them.