### PR TITLE
Bind to 127.0.0.1 by default instead of to 0.0.0.0

### DIFF
--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -372,7 +372,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
 #'
 #' @return Creates a recording file that can be used to drive a load test.
 #' @export
-record_session <- function(target_app_url, host = "0.0.0.0", port = 8600,
+record_session <- function(target_app_url, host = "127.0.0.1", port = 8600,
   output_file = "recording.log", open_browser = TRUE) {
     sessionCookies <- if (isProtected(target_app_url)) {
       username <- getPass::getPass("Enter your username: ")

--- a/man/record_session.Rd
+++ b/man/record_session.Rd
@@ -4,7 +4,7 @@
 \alias{record_session}
 \title{Record a Session for Load Test}
 \usage{
-record_session(target_app_url, host = "0.0.0.0", port = 8600,
+record_session(target_app_url, host = "127.0.0.1", port = 8600,
   output_file = "recording.log", open_browser = TRUE)
 }
 \arguments{
@@ -21,7 +21,7 @@ port 8600 is used by another service.}
 (default=\code{TRUE}) or not (\code{FALSE}).}
 }
 \value{
-Cerates a recording file that can be used to drive a load test.
+Creates a recording file that can be used to drive a load test.
 }
 \description{
 Record a Session for Load Test


### PR DESCRIPTION
This is mostly for security -- since we collect credentials from people, we should be available only on localhost by default.

It also fixes a problem on Windows, which is that 0.0.0.0 isn't an actual host you can navigate to, so `record_session` with `open_browser = TRUE` (the default) opens a browser but the browser can't find the host.