### PR TITLE
Clean if directories don't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ RELEASE_URLS.txt:
 site:
 	R -e 'devtools::document()'
 	R CMD INSTALL --no-multiarch --with-keep.source .
-	HEADLESS=TRUE Rscript scripts/test_sessions.R
+	HEADLESS=TRUE Rscript scripts/test_sessions.R && rm Rplots.pdf
 	Rscript scripts/build_vignettes.R
 	Rscript scripts/build_docs.R
 
 clean:
-	rm -rf output Rplots.pdf
+	rm -rf output
 	find vignettes/test_sessions/ -mindepth 1 -type d -delete

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-all: RELEASE_URLS.txt
+all: help
 
-.PHONY=clean site
+.PHONY=clean site help
+
+help:
+	@echo "make RELEASE_URLS.txt: update the shinycannon download links. You should do this after releasing shinycannon."
+	@echo "make site: build docs/vignettes and the doc site, which is hosted on github"
+	@echo "make clean: clean the docs and doc site"
 
 # Updates RELEASE_URLS.txt file.
 # Should be done manually when a new version of shinycannon is released.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ all: RELEASE_URLS.txt
 # Should be done manually when a new version of shinycannon is released.
 # RELEASE_URLS.txt is read by index.Rmd
 RELEASE_URLS.txt:
+	rm -f $@
 	wget https://s3.amazonaws.com/rstudio-shinycannon-build/$@
 
 site:
@@ -16,6 +17,5 @@ site:
 	Rscript scripts/build_docs.R
 
 clean:
-	rm -r output
-	ls -d vignettes/test_sessions/*/ | xargs rm -r
-	rm -f RELEASE_URLS.txt
+	rm -rf output Rplots.pdf
+	find vignettes/test_sessions/ -mindepth 1 -type d -delete


### PR DESCRIPTION
This small change makes `make clean` work even if `vignettes/test_sessions/*` directories don't exist yet. I also moved the step that deletes `RELEASE_URLS.txt` into the `RELEASE_URLS.txt` target, since updating that is a separate task than cleaning up.