### PR TITLE
Add Rmd + runtime shiny to limitations list

### DIFF
--- a/docs/articles/limitations-of-shinyloadtest.html
+++ b/docs/articles/limitations-of-shinyloadtest.html
@@ -110,6 +110,8 @@
 <ol style="list-style-type: decimal">
 <li>
 <strong>Apps must be deterministic</strong>: The recording file made by <code>record_session</code> contains messages from the server in the order they were received. If messages are received in a different order by <code>shinycannon</code> when it’s playing the recording back, that session will be considered a failure. If the same change in inputs does not always lead to outputs being updated in the same order, shinyloadtest will not work.</li>
+<li>
+<strong>RMarkdown documents with runtime Shiny are unsupported</strong>: Shiny apps embedded in <a href="https://rmarkdown.rstudio.com/">RMarkdown</a> (.rmd) documents are not currently supported.</li>
 </ol>
 </div>
   </div>

--- a/docs/articles/limitations-of-shinyloadtest.html
+++ b/docs/articles/limitations-of-shinyloadtest.html
@@ -111,7 +111,7 @@
 <li>
 <strong>Apps must be deterministic</strong>: The recording file made by <code>record_session</code> contains messages from the server in the order they were received. If messages are received in a different order by <code>shinycannon</code> when it’s playing the recording back, that session will be considered a failure. If the same change in inputs does not always lead to outputs being updated in the same order, shinyloadtest will not work.</li>
 <li>
-<strong>RMarkdown documents with runtime Shiny are unsupported</strong>: Shiny apps embedded in <a href="https://rmarkdown.rstudio.com/">RMarkdown</a> (.rmd) documents are not currently supported.</li>
+<strong>R Markdown documents with <code>runtime: shiny</code> unsupported</strong>: R Markdown documents that <a href="https://bookdown.org/yihui/rmarkdown/shiny-start.html">embed Shiny applications</a> are currently unsupported.</li>
 </ol>
 </div>
   </div>

--- a/inst/doc/limitations-of-shinyloadtest.html
+++ b/inst/doc/limitations-of-shinyloadtest.html
@@ -176,6 +176,7 @@ hr {
 
 <ol>
 <li><strong>Apps must be deterministic</strong>: The recording file made by <code>record_session</code> contains messages from the server in the order they were received. If messages are received in a different order by <code>shinycannon</code> when it&#39;s playing the recording back, that session will be considered a failure. If the same change in inputs does not always lead to outputs being updated in the same order, shinyloadtest will not work.</li>
+<li><strong>RMarkdown documents with runtime Shiny are unsupported</strong>: Shiny apps embedded in <a href="https://rmarkdown.rstudio.com/">RMarkdown</a> (.rmd) documents are not currently supported.</li>
 </ol>
 
 </body>

--- a/inst/doc/limitations-of-shinyloadtest.html
+++ b/inst/doc/limitations-of-shinyloadtest.html
@@ -176,7 +176,7 @@ hr {
 
 <ol>
 <li><strong>Apps must be deterministic</strong>: The recording file made by <code>record_session</code> contains messages from the server in the order they were received. If messages are received in a different order by <code>shinycannon</code> when it&#39;s playing the recording back, that session will be considered a failure. If the same change in inputs does not always lead to outputs being updated in the same order, shinyloadtest will not work.</li>
-<li><strong>RMarkdown documents with runtime Shiny are unsupported</strong>: Shiny apps embedded in <a href="https://rmarkdown.rstudio.com/">RMarkdown</a> (.rmd) documents are not currently supported.</li>
+<li><strong>R Markdown documents with <code>runtime: shiny</code> unsupported</strong>: R Markdown documents that <a href="https://bookdown.org/yihui/rmarkdown/shiny-start.html">embed Shiny applications</a> are currently unsupported.</li>
 </ol>
 
 </body>

--- a/vignettes/limitations-of-shinyloadtest.Rmd
+++ b/vignettes/limitations-of-shinyloadtest.Rmd
@@ -25,3 +25,4 @@ knitr::opts_chunk$set(
 ## Application limitations
 
 1. **Apps must be deterministic**: The recording file made by `record_session` contains messages from the server in the order they were received. If messages are received in a different order by `shinycannon` when it's playing the recording back, that session will be considered a failure. If the same change in inputs does not always lead to outputs being updated in the same order, shinyloadtest will not work.
+1. **RMarkdown documents with runtime Shiny are unsupported**: Shiny apps embedded in [RMarkdown](https://rmarkdown.rstudio.com/) (.rmd) documents are not currently supported.

--- a/vignettes/limitations-of-shinyloadtest.Rmd
+++ b/vignettes/limitations-of-shinyloadtest.Rmd
@@ -25,4 +25,4 @@ knitr::opts_chunk$set(
 ## Application limitations
 
 1. **Apps must be deterministic**: The recording file made by `record_session` contains messages from the server in the order they were received. If messages are received in a different order by `shinycannon` when it's playing the recording back, that session will be considered a failure. If the same change in inputs does not always lead to outputs being updated in the same order, shinyloadtest will not work.
-1. **RMarkdown documents with runtime Shiny are unsupported**: Shiny apps embedded in [RMarkdown](https://rmarkdown.rstudio.com/) (.rmd) documents are not currently supported.
+1. **R Markdown documents with `runtime: shiny` unsupported**: R Markdown documents that [embed Shiny applications](https://bookdown.org/yihui/rmarkdown/shiny-start.html) are currently unsupported.


### PR DESCRIPTION
@slopp spent time trying to get this to work because we forgot to document that it doesn't (yet). Added to limitations doc.