### PR TITLE
set limitsize=FALSE for ggsave

### DIFF
--- a/R/make_report.R
+++ b/R/make_report.R
@@ -346,7 +346,7 @@ save_svg <- function(p, output, width = 15, height = 10, units = "in", ...) {
       plot = p,
       width = width,
       height = height,
-      limitsize = FALSE, # image size is programatically increased and can be very tall
+      limitsize = FALSE, # image size is programmatically increased and can be very tall
       ...
     )
     # TODO make file smaller!

--- a/R/make_report.R
+++ b/R/make_report.R
@@ -341,7 +341,14 @@ save_svg <- function(p, output, width = 15, height = 10, units = "in", ...) {
     unlink(output_tmp)
   })
   suppressMessages({
-    ggplot2::ggsave(filename = output_tmp, plot = p, width = width, height = height, ...)
+    ggplot2::ggsave(
+      filename = output_tmp,
+      plot = p,
+      width = width,
+      height = height,
+      limitsize = FALSE, # image size is programatically increased and can be very tall
+      ...
+    )
     # TODO make file smaller!
   })
   # to_svgz(output_tmp, output)


### PR DESCRIPTION
Fixes #58 

https://www.rdocumentation.org/packages/ggplot2/versions/2.2.1/topics/ggsave

> limitsize
> When `TRUE` (the default), `ggsave` will not save images larger than 50x50 inches, to prevent the common error of specifying dimensions in pixels.

We can programmatically make some very tall graphics.  This should be FALSE.
