### PR TITLE
Fix compatibility with dplyr >=0.8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: shinyloadtest
 Type: Package
 Title: Load Test Shiny Applications
-Version: 1.0.0
+Version: 1.0.0.9000
 Authors@R: c(
             person("Alan", "Dipert", role = c("aut", "cre"), email = "alan@rstudio.com"),
             person("Barret", "Schloerke", role = c("aut"), email = "barret@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# shinyloadtest 1.0.0.9000
+
+- Fix compatibility with dplyr >=0.8
+
+
 # shinyloadtest 1.0.0
 
 - Initial public release

--- a/R/make_report.R
+++ b/R/make_report.R
@@ -104,7 +104,13 @@ shinyloadtest_report <- function(
     file.path(basename(base_output_name), svg_folder, paste0(file, ".svg"))
   }
 
-  df_maintenance <- df %>% filter(maintenance == TRUE)
+  df_maintenance <- df %>%
+    filter(maintenance == TRUE) %>%
+    # Must drop unused factor levels, or else we end up with
+    # NA rows under dplyr 0.8 and later due to
+    # https://github.com/tidyverse/dplyr/issues/341
+    # https://github.com/tidyverse/dplyr/pull/3492
+    mutate(label = droplevels(label))
 
   latency_height <- 10 * (
       (

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -148,6 +148,9 @@ slt_time_concurrency <- function(df, labels = NULL) {
     df <- df %>% filter(label %in% UQ(labels))
   }
 
+  # More dplyr 0.8 compatibility
+  df <- df %>% mutate(label = droplevels(label))
+
   p <- df %>%
     ggplot(aes(concurrency, time, fill = run, color = run)) +
     geom_point() +


### PR DESCRIPTION
In dplyr 0.8, `group_by` has changed behavior. If you group by a factor that has unused levels, previous versions of dplyr would not include those levels in summarised data frames; but the next dplyr release will include unused levels. This causes the `df_boxplot` temporary data frame to include rows that have `NA` times.

The fix was to explicitly drop unused levels from the `labels` column before doing any grouping.

# Testing notes

Repro by trying to run `shinyloadtest_report` with dplyr installed from GitHub master (`devtools::install_github("tidyverse/dplyr")`). Without this PR, you should get an error when processing the boxplots.