### PR TITLE
Clean up legend

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -598,12 +598,12 @@ slt_http_latency <- function(df, cutoff = 10) {
     # geom_hline(data = data.frame(y = cutoff, col = cutoff_color), mapping = aes(yintercept = y, color = I("transparent")), show.legend = TRUE) +
     geom_hline(yintercept = cutoff, color = cutoff_color) +
     request_scale_fill(
-      includeWarmup = TRUE, includeCutoff = TRUE,
-      limits = c("Homepage", "JS/CSS", "Warmup / Cooldown", "Cutoff")) +
+      includeWarmup = TRUE, includeCutoff = FALSE,
+      limits = c("Homepage", "JS/CSS", "Warmup / Cooldown")) +
     request_scale_color(
       includeWarmup = TRUE,
-      includeCutoff = TRUE,
-      limits = c("Homepage", "JS/CSS", "Warmup / Cooldown", "Cutoff")) +
+      includeCutoff = FALSE,
+      limits = c("Homepage", "JS/CSS", "Warmup / Cooldown")) +
     # scale_linetype_manual("asdf", values = c("Homepage" = "blank", "JS/CSS" = "blank", "Warmup / Cooldown" = "dotted", "Cutoff" = "solid"), limits = c("Homepage", "JS/CSS", "Warmup / Cooldown", "Cutoff")) +
     request_scale_guides(includeLineType = FALSE) +
     # geom_step(position = position_stack(reverse = TRUE)) +

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -496,12 +496,24 @@ slt_session_duration <- function(df, cutoff = c(attr(df, "recording_duration"), 
 
 latency_df <- function(df) {
   session_levels <- df$session_id %>% unique() %>% sort()
+
+  rename_event <- function(event) {
+    switch(event,
+      REQ_HOME = "Homepage",
+      REQ_GET = "JS/CSS",
+      WS_OPEN = "Start session",
+      WS_RECV = "Calculate",
+      WS_SEND = "Calculate",
+      event
+    )
+  }
+
   df_sum <- df %>%
     filter(event != "WS_RECV_INIT") %>%
     # mutate(session_id = factor(session_id, levels = rev(unique(session_id)))) %>%
     mutate(user_id = paste0("w:", user_id)) %>%
     mutate(session_id = factor(session_id, levels = session_levels)) %>%
-    mutate(event = c(REQ_HOME="Homepage", REQ_GET="JS/CSS", WS_OPEN="Start session", WS_RECV="Calculate", WS_SEND="Calculate")[event]) %>%
+    mutate(event = vapply(event, rename_event, character(1))) %>%
     mutate(event = factor(event,
       levels = c("Homepage", "JS/CSS", "Start session", "Calculate"))) %>%
     group_by(run, session_id, event, user_id, maintenance) %>%


### PR DESCRIPTION
Drops an empty "Cutoff" legend box from latency plot as it can not be displayed.

Now looks like:

![http_latency](https://user-images.githubusercontent.com/93231/51001462-29f9db80-14fe-11e9-98fc-31606c2dfb38.png)
