### PR TITLE
Fix authenticated SSP recording bug introduced by #107

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -1,11 +1,11 @@
 
 getInputs <- function(html, server) {
-  if (server == "ssp") {
+  if (server == SERVER_TYPE$SSP) {
     inputs <- xml2::xml_find_all(html, "//input[@type='hidden']")
     attrs <- xml2::xml_attrs(inputs)
     attrs <- lapply(attrs, function(vec) c(name = vec[["name"]], value = vec[["value"]]))
     as.data.frame(do.call(rbind, attrs), stringsAsFactors = FALSE)
-  }
+  } else data.frame()
 }
 
 pasteParams <- function(df, collapse) {
@@ -47,7 +47,7 @@ handlePost <- function(handle, loginUrl, postfields, cookies, cookieName) {
   )
 
   resp <- curl::curl_fetch_memory(loginUrl$build(), handle = handle)
-  if (resp$status_code != 200) stop("Authentication failed")
+  if (!(resp$status_code %in% c(200, 302))) stop("Authentication failed")
 
   curl::handle_cookies(handle)[,c("name", "value")]
 }


### PR DESCRIPTION
I missed a place where the new enum-based server type needed to be used which broke recording of SSP apps requiring authentication.

While I was in there I made sure `getInputs()` always a returns a (possibly empty) data frame.

Then, I check both for 200 and for 302 to check for auth success (SSP redirects after authenticating)