### PR TITLE
Use Markdown in Roxygen comments, expand record_session docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,6 +50,7 @@ Remotes:
   rstudio/websocket,
   rstudio/httpuv@8492695
 RoxygenNote: 6.1.1
+Roxygen: list(markdown = TRUE)
 Suggests:
     knitr,
     testthat

--- a/R/analysis.R
+++ b/R/analysis.R
@@ -219,7 +219,7 @@ get_times <- function(df) {
 # Tidying functions -------------------------------------------------------
 
 #' Create Tidy Load Test Results
-#' @description The \code{shinycannon} tool creates a directory of log files for
+#' @description The `shinycannon` tool creates a directory of log files for
 #'   each load test. This function translates one or more test result
 #'   directories into a tidy data frame.
 #' @param ...  Key-value pairs where the key is the desired name for the test and the

--- a/R/make_report.R
+++ b/R/make_report.R
@@ -6,9 +6,9 @@ if (getRversion() >= "2.15.1") {
 
 #' Make shinyloadtest Report
 #'
-#' @param df data.frame returned from \code{\link{load_runs}}
+#' @param df data.frame returned from [load_runs()]
 #' @param output File where HTML output should be saved
-#' @param duration_cutoff Cutoff value for session duration plot. Defaults to the recording duration used to simulate \code{df} or 60 seconds.
+#' @param duration_cutoff Cutoff value for session duration plot. Defaults to the recording duration used to simulate `df` or 60 seconds.
 #' @param http_latency_cutoff Cutoff value for total http latency plot
 #' @param max_websocket_cutoff Cutoff value for max websocket latency plot
 #' @param verbose Boolean that determines if progress output is displayed

--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -456,22 +456,49 @@ RecordingSession <- R6::R6Class("RecordingSession",
 
 #' Record a Session for Load Test
 #'
-#' This function creates a reverse proxy listening at `host:port`
-#' that stands in front of `target_app_url`. As the user interacts with
-#' the app, the actions and responses are recorded in a file that can be
-#' replayed later. By default, a web browser is opened automatically so that
-#' you can begin recording immediately, without manually starting a browser
-#' and navigating to `host:port`.
+#' This function creates a [reverse
+#' proxy](https://en.wikipedia.org/wiki/Reverse_proxy) listening at `host:port`
+#' that intercepts and records activity between your web browser and the Shiny
+#' application at `target_app_url`.
 #'
-#' @param target_app_url The URL of the deployed application
+#' By default, after creating the reverse proxy, a web browser is opened
+#' automatically. This behavior is controlled by `open_browser`. As you interact
+#' with the application in the web browser, activity is written to the
+#' `output_file`, which defaults to `recording.log`.
+#'
+#' To shut down the reverse proxy and complete the recording, close the web
+#' browser tab or window.
+#'
+#' Recordings are used as input to the `shinycannon` command-line
+#' load-generation tool which can be obtained from the [shinyloadtest
+#' documentation site](https://rstudio.github.io/shinyloadtest/index.html).
+#'
+#' @section `fileInput`/`DT`/`HTTP POST` support:
+#'
+#' Shiny's [shiny::fileInput()] input for uploading files, the `DT` package, and
+#' potentially other packages make HTTP POST requests to the target application.
+#' Because POST requests can be large, they are not stored directly in the
+#' recording file. Instead, new files adjacent to the recording are created when
+#' an HTTP POST request is intercepted.
+#'
+#' The adjacent files are named after the recording with the pattern
+#' `<output_file>.post.<N>`, where `<output_file>` is the chosen recording file
+#' name and `<N>` is the number of the request.
+#'
+#' If present, these adjacent files must be kept alongside the recording file
+#' when the recording is played back with the `shinycannon` tool.
+#'
+#' @param target_app_url The URL of the deployed application.
 #' @param host The host where the proxy will run. Usually localhost is used.
-#' @param output_file The name for the generated log file.
-#' @param open_browser Whether to open a browser on the proxy
-#'   (default=`TRUE`) or not (`FALSE`).
-#' @param port The port for the proxy. Default is 8600. Change this default if
-#'   port 8600 is used by another service.
+#' @param output_file The name of the generated recording file.
+#' @param open_browser Whether to open a browser on the proxy (default=`TRUE`)
+#'   or not (`FALSE`).
+#' @param port The port for the reverse proxy. Default is 8600. Change this
+#'   default if port 8600 is used by another service.
 #'
-#' @return Creates a recording file that can be used to drive a load test.
+#' @return Creates a recording file that can be used as input to the
+#'   `shinycannon` command-line load generation tool.
+#' @seealso `browseVignettes("shinyloadtest")`
 #' @export
 record_session <- function(target_app_url, host = "127.0.0.1", port = 8600,
   output_file = "recording.log", open_browser = TRUE) {

--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -455,17 +455,19 @@ RecordingSession <- R6::R6Class("RecordingSession",
 )
 
 #' Record a Session for Load Test
-#' @details This function creates a reverse proxy listening at \code{host:port}
-#'   that stands in front of \code{target_app_url}. As the user interacts with
-#'   the app, the actions and responses are recorded in a file that can be
-#'   replayed later. By default, a web browser is opened automatically so that
-#'   you can begin recording immediately, without manually starting a browser
-#'   and navigating to \code{host:port}.
+#'
+#' This function creates a reverse proxy listening at `host:port`
+#' that stands in front of `target_app_url`. As the user interacts with
+#' the app, the actions and responses are recorded in a file that can be
+#' replayed later. By default, a web browser is opened automatically so that
+#' you can begin recording immediately, without manually starting a browser
+#' and navigating to `host:port`.
+#'
 #' @param target_app_url The URL of the deployed application
 #' @param host The host where the proxy will run. Usually localhost is used.
 #' @param output_file The name for the generated log file.
 #' @param open_browser Whether to open a browser on the proxy
-#'   (default=\code{TRUE}) or not (\code{FALSE}).
+#'   (default=`TRUE`) or not (`FALSE`).
 #' @param port The port for the proxy. Default is 8600. Change this default if
 #'   port 8600 is used by another service.
 #'

--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -457,14 +457,13 @@ RecordingSession <- R6::R6Class("RecordingSession",
 #' Record a Session for Load Test
 #'
 #' This function creates a [reverse
-#' proxy](https://en.wikipedia.org/wiki/Reverse_proxy) listening at `host:port`
-#' that intercepts and records activity between your web browser and the Shiny
-#' application at `target_app_url`.
+#' proxy](https://en.wikipedia.org/wiki/Reverse_proxy) at `http://host:port`
+#' (http://127.0.0.1:8600 by default) that intercepts and records activity
+#' between your web browser and the Shiny application at `target_app_url`.
 #'
 #' By default, after creating the reverse proxy, a web browser is opened
-#' automatically. This behavior is controlled by `open_browser`. As you interact
-#' with the application in the web browser, activity is written to the
-#' `output_file`, which defaults to `recording.log`.
+#' automatically. As you interact with the application in the web browser,
+#' activity is written to the `output_file` (`recording.log` by default).
 #'
 #' To shut down the reverse proxy and complete the recording, close the web
 #' browser tab or window.
@@ -475,18 +474,18 @@ RecordingSession <- R6::R6Class("RecordingSession",
 #'
 #' @section `fileInput`/`DT`/`HTTP POST` support:
 #'
-#' Shiny's [shiny::fileInput()] input for uploading files, the `DT` package, and
-#' potentially other packages make HTTP POST requests to the target application.
-#' Because POST requests can be large, they are not stored directly in the
-#' recording file. Instead, new files adjacent to the recording are created when
-#' an HTTP POST request is intercepted.
+#'   Shiny's [shiny::fileInput()] input for uploading files, the `DT` package,
+#'   and potentially other packages make HTTP POST requests to the target
+#'   application. Because POST requests can be large, they are not stored
+#'   directly in the recording file. Instead, new files adjacent to the
+#'   recording are created for each HTTP POST request intercepted.
 #'
-#' The adjacent files are named after the recording with the pattern
-#' `<output_file>.post.<N>`, where `<output_file>` is the chosen recording file
-#' name and `<N>` is the number of the request.
+#'   The adjacent files are named after the recording with the pattern
+#'   `<output_file>.post.<N>`, where `<output_file>` is the chosen recording
+#'   file name and `<N>` is the number of the request.
 #'
-#' If present, these adjacent files must be kept alongside the recording file
-#' when the recording is played back with the `shinycannon` tool.
+#'   If present, these adjacent files must be kept alongside the recording file
+#'   when the recording is played back with the `shinycannon` tool.
 #'
 #' @param target_app_url The URL of the deployed application.
 #' @param host The host where the proxy will run. Usually localhost is used.

--- a/man/load_runs.Rd
+++ b/man/load_runs.Rd
@@ -14,12 +14,12 @@ value is a path to the test result directory.}
 }
 \value{
 A tidy data frame with the test result data. Each row is an event. Columns include
-   identifiers and timing information for the event.
+identifiers and timing information for the event.
 }
 \description{
 The \code{shinycannon} tool creates a directory of log files for
-  each load test. This function translates one or more test result
-  directories into a tidy data frame.
+each load test. This function translates one or more test result
+directories into a tidy data frame.
 }
 \examples{
 \dontrun{

--- a/man/record_session.Rd
+++ b/man/record_session.Rd
@@ -8,26 +8,56 @@ record_session(target_app_url, host = "127.0.0.1", port = 8600,
   output_file = "recording.log", open_browser = TRUE)
 }
 \arguments{
-\item{target_app_url}{The URL of the deployed application}
+\item{target_app_url}{The URL of the deployed application.}
 
 \item{host}{The host where the proxy will run. Usually localhost is used.}
 
-\item{port}{The port for the proxy. Default is 8600. Change this default if
-port 8600 is used by another service.}
+\item{port}{The port for the reverse proxy. Default is 8600. Change this
+default if port 8600 is used by another service.}
 
-\item{output_file}{The name for the generated log file.}
+\item{output_file}{The name of the generated recording file.}
 
-\item{open_browser}{Whether to open a browser on the proxy
-(default=\code{TRUE}) or not (\code{FALSE}).}
+\item{open_browser}{Whether to open a browser on the proxy (default=\code{TRUE})
+or not (\code{FALSE}).}
 }
 \value{
-Creates a recording file that can be used to drive a load test.
+Creates a recording file that can be used as input to the
+\code{shinycannon} command-line load generation tool.
 }
 \description{
-This function creates a reverse proxy listening at \code{host:port}
-that stands in front of \code{target_app_url}. As the user interacts with
-the app, the actions and responses are recorded in a file that can be
-replayed later. By default, a web browser is opened automatically so that
-you can begin recording immediately, without manually starting a browser
-and navigating to \code{host:port}.
+This function creates a \href{https://en.wikipedia.org/wiki/Reverse_proxy}{reverse proxy} listening at \code{host:port}
+that intercepts and records activity between your web browser and the Shiny
+application at \code{target_app_url}.
+}
+\details{
+By default, after creating the reverse proxy, a web browser is opened
+automatically. This behavior is controlled by \code{open_browser}. As you interact
+with the application in the web browser, activity is written to the
+\code{output_file}, which defaults to \code{recording.log}.
+
+To shut down the reverse proxy and complete the recording, close the web
+browser tab or window.
+
+Recordings are used as input to the \code{shinycannon} command-line
+load-generation tool which can be obtained from the \href{https://rstudio.github.io/shinyloadtest/index.html}{shinyloadtest documentation site}.
+}
+\section{\code{fileInput}/\code{DT}/\code{HTTP POST} support}{
+
+
+Shiny's \code{\link[shiny:fileInput]{shiny::fileInput()}} input for uploading files, the \code{DT} package, and
+potentially other packages make HTTP POST requests to the target application.
+Because POST requests can be large, they are not stored directly in the
+recording file. Instead, new files adjacent to the recording are created when
+an HTTP POST request is intercepted.
+
+The adjacent files are named after the recording with the pattern
+\code{<output_file>.post.<N>}, where \code{<output_file>} is the chosen recording file
+name and \code{<N>} is the number of the request.
+
+If present, these adjacent files must be kept alongside the recording file
+when the recording is played back with the \code{shinycannon} tool.
+}
+
+\seealso{
+\code{browseVignettes("shinyloadtest")}
 }

--- a/man/record_session.Rd
+++ b/man/record_session.Rd
@@ -24,13 +24,10 @@ port 8600 is used by another service.}
 Creates a recording file that can be used to drive a load test.
 }
 \description{
-Record a Session for Load Test
-}
-\details{
 This function creates a reverse proxy listening at \code{host:port}
-  that stands in front of \code{target_app_url}. As the user interacts with
-  the app, the actions and responses are recorded in a file that can be
-  replayed later. By default, a web browser is opened automatically so that
-  you can begin recording immediately, without manually starting a browser
-  and navigating to \code{host:port}.
+that stands in front of \code{target_app_url}. As the user interacts with
+the app, the actions and responses are recorded in a file that can be
+replayed later. By default, a web browser is opened automatically so that
+you can begin recording immediately, without manually starting a browser
+and navigating to \code{host:port}.
 }

--- a/man/record_session.Rd
+++ b/man/record_session.Rd
@@ -25,15 +25,14 @@ Creates a recording file that can be used as input to the
 \code{shinycannon} command-line load generation tool.
 }
 \description{
-This function creates a \href{https://en.wikipedia.org/wiki/Reverse_proxy}{reverse proxy} listening at \code{host:port}
-that intercepts and records activity between your web browser and the Shiny
-application at \code{target_app_url}.
+This function creates a \href{https://en.wikipedia.org/wiki/Reverse_proxy}{reverse proxy} at \code{http://host:port}
+(http://127.0.0.1:8600 by default) that intercepts and records activity
+between your web browser and the Shiny application at \code{target_app_url}.
 }
 \details{
 By default, after creating the reverse proxy, a web browser is opened
-automatically. This behavior is controlled by \code{open_browser}. As you interact
-with the application in the web browser, activity is written to the
-\code{output_file}, which defaults to \code{recording.log}.
+automatically. As you interact with the application in the web browser,
+activity is written to the \code{output_file} (\code{recording.log} by default).
 
 To shut down the reverse proxy and complete the recording, close the web
 browser tab or window.
@@ -44,15 +43,15 @@ load-generation tool which can be obtained from the \href{https://rstudio.github
 \section{\code{fileInput}/\code{DT}/\code{HTTP POST} support}{
 
 
-Shiny's \code{\link[shiny:fileInput]{shiny::fileInput()}} input for uploading files, the \code{DT} package, and
-potentially other packages make HTTP POST requests to the target application.
-Because POST requests can be large, they are not stored directly in the
-recording file. Instead, new files adjacent to the recording are created when
-an HTTP POST request is intercepted.
+Shiny's \code{\link[shiny:fileInput]{shiny::fileInput()}} input for uploading files, the \code{DT} package,
+and potentially other packages make HTTP POST requests to the target
+application. Because POST requests can be large, they are not stored
+directly in the recording file. Instead, new files adjacent to the
+recording are created for each HTTP POST request intercepted.
 
 The adjacent files are named after the recording with the pattern
-\code{<output_file>.post.<N>}, where \code{<output_file>} is the chosen recording file
-name and \code{<N>} is the number of the request.
+\code{<output_file>.post.<N>}, where \code{<output_file>} is the chosen recording
+file name and \code{<N>} is the number of the request.
 
 If present, these adjacent files must be kept alongside the recording file
 when the recording is played back with the \code{shinycannon} tool.

--- a/man/shinyloadtest_report.Rd
+++ b/man/shinyloadtest_report.Rd
@@ -10,7 +10,7 @@ shinyloadtest_report(df, output = "shinyloadtest_report.html",
   open_browser = TRUE, self_contained = TRUE, verbose = TRUE)
 }
 \arguments{
-\item{df}{data.frame returned from \code{\link{load_runs}}}
+\item{df}{data.frame returned from \code{\link[=load_runs]{load_runs()}}}
 
 \item{output}{File where HTML output should be saved}
 


### PR DESCRIPTION
@shalutiwari discovered recently that we don't document anywhere how POST requests are handled, and the fact that files other than the recording are created when HTTP POSTs are sent through the reverse proxy.

I expanded the `record_session()` documentation to include a section describing how we handle POSTs. Along the way, I took the opportunity to get us rolling on [Markdown-flavored Roxygen](https://cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html).

Note that this will need the `make site` treatment once accepted.