### PR TITLE
Display a message with created files when recording stops

### DIFF
--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -215,9 +215,9 @@ RecordingSession <- R6::R6Class("RecordingSession",
         httpuv::interrupt()
         private$localServer <- NULL
         close(private$outputFile)
-        if (length(fileList)) {
+        if (length(private$postFiles)) {
           fileList <- paste(sprintf("\t%s", private$postFiles), collapse = '\n')
-          message("Note: the following files containing uploaded data were created. They must be kept with the recording file.\n", fileList)
+          message("Note: uploaded files to keep with recording file:\n", fileList)
         }
       }
     },

--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -215,6 +215,10 @@ RecordingSession <- R6::R6Class("RecordingSession",
         httpuv::interrupt()
         private$localServer <- NULL
         close(private$outputFile)
+        if (length(fileList)) {
+          fileList <- paste(sprintf("\t%s", private$postFiles), collapse = '\n')
+          message("Note: the following files containing uploaded data were created. They must be kept with the recording file.\n", fileList)
+        }
       }
     },
     # An environment of session-specific identifier strings to their
@@ -231,7 +235,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
     outputFile = NULL,
     sessionCookies = data.frame(),
     clientWsState = CLIENT_WS_STATE$UNOPENED,
-    postFileCounter = 0,
+    postFiles = character(0),
     writeEvent = function(evt) {
       writeLines(format(evt), private$outputFile)
       flush(private$outputFile)
@@ -284,7 +288,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
         # TODO Figure out how to use CURL_INFILESIZE_LARGE to upload files
         # larger than 2GB.
         curl::handle_setopt(h, post = TRUE, infilesize = as.integer(req$HTTP_CONTENT_LENGTH))
-        dataFileName <- sprintf("%s.post.%d", private$outputFileName, private$postFileCounter)
+        dataFileName <- sprintf("%s.post.%d", private$outputFileName, length(private$postFiles))
         writeCon <- file(dataFileName, "wb")
         curl::handle_setopt(h, readfunction = function(n) {
           data <- req$rook.input$read(n)
@@ -294,7 +298,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
         on.exit({
           flush(writeCon)
           close(writeCon)
-          private$postFileCounter <- private$postFileCounter + 1
+          private$postFiles <- c(private$postFiles, dataFileName)
         })
       }
 


### PR DESCRIPTION
It can be confusing to people that when data is POSTed, such as via DT or fileInput, the uploaded data is not contained in the recording file but instead is stored in auxiliary files.

Recently we [documented](https://github.com/rstudio/shinyloadtest/pull/113) the behavior, which will help.

This PR goes a step further and notifies the user when the recording stops that files have been created.

Here's an example of what the new behavior looks like in the R console:

```
> record_session("https://my.rsc.com/content/4223/", output_file = "upload.log")
Listening on 127.0.0.1:8600
Navigating to: http://127.0.0.1:8600/
Client connected
Client disconnected
Stopping server
Note: uploaded files to keep with recording file:
	upload.log.post.0
	upload.log.post.1
Server disconnected
```