### PR TITLE
Properly overwrite request cookies if authentication is used

### DIFF
--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -267,7 +267,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
       h <- curl::new_handle()
 
       if (nrow(private$sessionCookies) > 0) {
-        req_curl[["Cookie"]] <- pasteParams(private$sessionCookies, "; ")
+        req_curl[["cookie"]] <- pasteParams(private$sessionCookies, "; ")
       }
 
       curl::handle_setheaders(h, .list = req_curl)


### PR DESCRIPTION
Previously, if we obtained any cookies from the authentication request we sent, we were adding a second `Cookie` header to the client's request instead of overwriting their provided `cookie` header.

This meant that if the client already had a meaningful cookie left over from some previous recording session (such as the `session_state` cookie) it would be sent. If the server being recorded wasn't the same as that which generated the cookie, it would fail to decrypt the cookie and the client would be sent to the login screen.

This fixes the casing of the header field we overwrite so that only one `cookies` header is sent, which assures that only one (and the correct) session_state cookie is sent.