### PR TITLE
Simplify and fix the way URL path components are handled

### DIFF
--- a/R/auth.R
+++ b/R/auth.R
@@ -29,7 +29,7 @@ isProtected <- function(appUrl) {
 
 loginUrlFor <- function(appUrl, appServer) {
   if (appServer %in% c(SERVER_TYPE$RSC, SERVER_TYPE$SSP)) {
-    appUrl$appendPaths("__login__")
+    appUrl$appendPath("__login__")
   } else {
     stop(paste0("Unknown appServer:", appServer))
   }

--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -259,7 +259,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
     },
     makeUrl = function(req) {
       query <- gsub("\\?", "", req$QUERY_STRING)
-      private$targetURL$appendPaths(req$PATH_INFO)$setQuery(query)$build()
+      private$targetURL$appendPath(req$PATH_INFO)$setQuery(query)$build()
     },
     makeCurlHandle = function(req) {
       port <- private$targetURL$port %OR% if (private$targetURL$scheme == "https") 443 else 80
@@ -352,7 +352,7 @@ RecordingSession <- R6::R6Class("RecordingSession",
       private$writeEvent(makeWSEvent("WS_OPEN", url =  replaceTokens(clientWS$request$PATH_INFO, self$tokens)))
 
       wsScheme <- if (private$targetURL$scheme == "https") "wss" else "ws"
-      wsUrl <- private$targetURL$setScheme(wsScheme)$appendPaths(clientWS$request$PATH_INFO)$build()
+      wsUrl <- private$targetURL$setScheme(wsScheme)$appendPath(clientWS$request$PATH_INFO)$build()
 
       serverWS <- websocket::WebSocket$new(wsUrl,
         headers = if (nrow(private$sessionCookies) > 0) {
@@ -510,7 +510,7 @@ record_session <- function(target_app_url, host = "127.0.0.1", port = 8600,
     message("Listening on ", host, ":", port)
 
     if (open_browser){
-      navUrl <- URLBuilder$new(target_app_url)$setHost(host)$setPort(port)$setScheme("http")$setPaths("")$build()
+      navUrl <- URLBuilder$new(target_app_url)$setHost(host)$setPort(port)$setScheme("http")$setPath("")$build()
       message("Navigating to: ", navUrl)
       utils::browseURL(navUrl)
     }

--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -36,11 +36,7 @@ req_rook_to_curl <- function(req, domain, port) {
   names(r) <- tolower(names(r))
 
   # Overwrite host field
-  if (port == 80) {
-    r$host <- domain
-  } else {
-    r$host <- paste0(domain, ":", port)
-  }
+  r$host <- domain
 
   r[headers_to_remove(r$connection)] <- NULL
 

--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -49,6 +49,7 @@ resp_httr_to_rook <- function(resp) {
   headers <- curl::parse_headers_list(resp$headers)
   headers[headers_to_remove(headers$connection)] <- NULL
   headers[["content-encoding"]] <- NULL
+  headers[["content-length"]] <- length(resp$content)
   list(
     status = status,
     headers = headers,

--- a/tests/testthat/test-url-construction.R
+++ b/tests/testthat/test-url-construction.R
@@ -5,6 +5,11 @@ test_that("basic URL without path is created", {
   expect_equal(url, URLBuilder$new(url)$build())
 })
 
+test_that("for basic URL with path, trailing slash is preserved", {
+  url <- "http://example.com/foobar/"
+  expect_equal(url, URLBuilder$new(url)$build())
+})
+
 test_that("basic URL with non-standard port is created", {
   url <- "http://example.com:8383/"
   expect_equal(url, URLBuilder$new(url)$build())
@@ -13,13 +18,13 @@ test_that("basic URL with non-standard port is created", {
 test_that("setting raw path works", {
   url <- "http://example.com/foo/bar"
   builder <- URLBuilder$new(url)
-  expect_equal("http://example.com/foop/barp", builder$setPaths("foop/barp")$build())
+  expect_equal("http://example.com/foop/barp", builder$setPath("foop/barp")$build())
 })
 
 test_that("appending path works", {
   url <- "http://example.com/foo/bar"
   builder <- URLBuilder$new(url)
-  expect_equal("http://example.com/foo/bar/foop/barp", builder$appendPaths("foop/barp")$build())
+  expect_equal("http://example.com/foo/bar/foop/barp", builder$appendPath("foop/barp")$build())
 })
 
 test_that("handles URL scheme properly", {
@@ -41,6 +46,6 @@ test_that("basic query string round-tripping", {
 test_that("URLs with query strings can be modified", {
   url_string_before <- "http://foo.com/?pizzazz=true&flair=false"
   url_string_after <- "http://foo.com/foo?pizzazz=true&flair=false"
-  url <- URLBuilder$new(url_string_before)$appendPaths("foo")
+  url <- URLBuilder$new(url_string_before)$appendPath("foo")
   expect_equal(url_string_after, url$build())
 })


### PR DESCRIPTION
## Context

There are 3 changes in this PR. One is big and two are small.

1. Big: URLBuilder improvements. Details below.
1. Small: Simplify `Host` header creation. Previously we included the port in the `Host` header after the domain, if the target application had an `https` protocol. Apparently, while the port number here is [optional](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host), no browsers actually do this, and it can confuse proxies. Now, we just use the target domain for `Host` and it seems to have resolved a problem for a customer.
1. Small: Specify proper `content-length` header in response. The `curl` package we use automatically decompresses responses, but we were blindly copying the original response's `content-length` header -- which reflected the gzip'd size -- instead of synthesizing a new, correct header based on the uncompressed size. Fixed it.

Details on the big change are below

### Big change: URLBuilder improvements

Because we do a lot of URL manipulation in shinyloadtest, we have a little R6-based helper library, the `URLBuilder` class, to help us out. It's a URL builder with a [fluent](https://en.wikipedia.org/wiki/Fluent_interface#Java) API in the spirit of [uribuilder-tiny](https://github.com/moznion/uribuilder-tiny) for Java.

Unfortunately, prior to this PR, the code in `URLBuilder` around appending paths was quite complex. In particular, it was complex because of the representation I chose for the `path` component of the URL, maintained internally as `self$path`. We even had a `TODO` in there about cleaning it up because we never felt great about it.

I wanted to protect myself from constructing URLs with too many `/` (slashes) in between path components when `$appendPaths()` was called. So, I decided to represent the `path` component of the URL internally as a character vector of parts without any slashes. That way, to append, one simply concatenated character vectors. The slashes were then added inside `$build()` when a string URL needed to be produced.

The bug with this approach was that the representation was lossy. It was lossy because if you passed it a URL like `http://example.com/foo/`, it would initially populate `self$paths` with a vector like `c("foo")`. Then, at `$build()` time, it would join the path components to produce e.g. `http://example.com/foo`, which isn't the same URL that was passed in — it's missing the trailing `/`.

This lossiness didn't matter for a long time because all of the apps we test with apparently weren't sensitive to this. However, eventually a customer reported problems recording their app, and it turned out to be this bug in the wild.

### URLBuilder Fix

The fix was simple, and obvious to the present-time version of myself. We just need to make sure we don't duplicate slashes when we join path component strings. This is achieved with a simple check of whether the left and right components end and start with slashes, respectively, and then conditionally inserting a slash, removing one, or just joining the strings, depending.

* In the PR, the new helper function `joinPaths()` in `R/url.R` does the slash-aware join.
* In URLBuilder the path component is now represented as a length-1 character vector instead of a length-n vector, `self$path` (was `self$paths`)
* Since `xml2:url_parse()` calls the path component `path`, we now call it `path` instead of `paths` everywhere ourselves. That meant also changing `$setPaths()` to `$setPath()` and `$appendPaths()` to `$appendPath()`.
* I removed an optional parameter, `raw`, from `$setPath()` and `$appendPath()` because it's something I originally thought we would need, but never have. None of the paths we append ever need to be URL encoded.
* I added a test case ensuring the trailing slash of a path isn't lost, which fixes the customer issue that caused us to revisit this.