### PR TITLE
Move report gen test from @examples to testthat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ r:
   - oldrel
   - release
   - devel
+r_check_args: "--as-cran --run-donttest"
 
 jobs:
   include:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,11 +8,11 @@ Authors@R: c(
             person("Barbara", "Borges", role = c("aut")),
             person("RStudio", role = c("cph", "fnd"))
             )
-Description: Tools for assessing the number of concurrent users 'shiny' 
+Description: Tools for assessing the number of concurrent users 'shiny'
   applications are capable of supporting, and for directing application changes
   in order to support a higher number of users. Provides facilities for recording
-  'shiny' application sessions, playing recorded sessions against a target 
-  server at load, and analyzing the resulting metrics. 
+  'shiny' application sessions, playing recorded sessions against a target
+  server at load, and analyzing the resulting metrics.
 License: GPL-3
 Depends:
   R (>= 2.10)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Imports:
     svglite,
     websocket (>= 1.0.0),
     xml2
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
 Suggests:
     testthat,

--- a/R/make_report.R
+++ b/R/make_report.R
@@ -15,10 +15,9 @@ if (getRversion() >= "2.15.1") {
 #' @param self_contained Boolean that determines if the final output should be a self contained html file
 #' @param open_browser Whether to open the created output in the browser
 #' @examples
-#'   # Run best with example(shinyloadtest_report, ask = FALSE)
-#'   html_file <- sprintf("%s.html", tempfile("report"))
-#'   message(sprintf("Generating report: %s", html_file))
-#'   shinyloadtest_report(slt_demo_data_1, output = html_file)
+#' \dontrun{
+#'   shinyloadtest_report(slt_demo_data_1)
+#' }
 #' @export
 shinyloadtest_report <- function(
   df,

--- a/R/make_report.R
+++ b/R/make_report.R
@@ -130,7 +130,7 @@ shinyloadtest_report <- function(
   # gantt chart plots
   min_gantt_time <- min(df$start)
   max_gantt_time <- max(df$end)
-  max_duration <- max(gantt_duration_data(df)$end)
+  max_duration <- max(c(gantt_duration_data(df)$end, duration_cutoff))
   gantt <- lapply(levels(df$run), function(run_val) {
     run_val_clean <-
       run_val %>%

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -22,7 +22,9 @@ NULL
 #' @rdname slt_plot
 #' @return A \code{\link[ggplot2]{ggplot}} plot object
 #' @examples
-#' slt_time_boxplot(slt_demo_data_16)
+#' slt_session_duration(slt_demo_data_4)
+#'
+#' \donttest{slt_time_boxplot(slt_demo_data_16)
 #' slt_time_concurrency(slt_demo_data_16)
 #' slt_waterfall(slt_demo_data_16)
 #' slt_hist_loadtimes(slt_demo_data_16)
@@ -31,7 +33,7 @@ NULL
 #' slt_session_duration(slt_demo_data_16)
 #' slt_session_latency(slt_demo_data_16)
 #' slt_http_latency(slt_demo_data_16)
-#' slt_websocket_latency(slt_demo_data_16)
+#' slt_websocket_latency(slt_demo_data_16)}
 NULL
 
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -40,7 +40,7 @@ The following changes addressing reviewer feedback were made:
 
 There were no ERRORs or WARNINGs.
 
-Sometimes a NOTE about example running time is produced; it is caused by the slt_* examples suggested by CRAN review.
+Sometimes a NOTE about example running time > 5 seconds is produced; it is caused by the new slt_* examples.
 
 ## Downstream dependencies
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-# 2019-12-04 1.0.0
+# 2019-12-06 1.0.0
 
 This is a re-submission addressing the following reviewer feedback e-mail:
 
@@ -27,8 +27,8 @@ The following changes addressing reviewer feedback were made:
 3. Running \examples were added to the slt_plot topic
 4. \value was added to load_runs()
 5. A \dontrun \example was added to record_session(). \dontrun used because record_session() starts a server.
-6. Example datasets suitable for passing to shinyloadtest_report() were added: slt_demo_data_1, slt_demo_data_4, and slt_demo_data_16
-7. A running example using a provided example dataset was added to shinyloadtest_report()
+6. A \dontrun \example was added to shinyloadtest_report(). \dontrun used because CRAN servers don't have a recent enough pandoc for it to work.
+7. Example datasets suitable for passing to shinyloadtest_report() were added: slt_demo_data_1, slt_demo_data_4, and slt_demo_data_16
 
 ## Test environments
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -36,7 +36,7 @@ The following changes addressing reviewer feedback were made:
 * Ubuntu 18.04: R 3.6.1
 * Travis Ubuntu 16.04: oldrelease, release, devel
 * win-builder: oldrelease, release, devel
-* rhub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
+* rhub: windows-x86_64-devel, ubuntu-gcc-release
 
 ## R CMD check results
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,19 +4,19 @@ This is a re-submission addressing the following reviewer feedback e-mail:
 
 > The Description field is intended to be a (one paragraph) description
 > of what the package does and why it may be useful. Please elaborate.
-> 
-> Please add \value to .Rd files that are not data files and explain the 
+>
+> Please add \value to .Rd files that are not data files and explain the
 > functions results in the documentation.
 > f.i.: slt_plot.Rd
-> If a function does not return a value, please document that too, e.g. 
+> If a function does not return a value, please document that too, e.g.
 > \value{None}.
-> 
-> Please add small executable examples in your Rd-files to illustrate the 
+>
+> Please add small executable examples in your Rd-files to illustrate the
 > use of the exported function but also enable automatic testing.
-> 
-> Please fix and resubmit, and document what was changed in the submission 
+>
+> Please fix and resubmit, and document what was changed in the submission
 > comments.
-> 
+>
 > Best,
 > Jelena Saf
 
@@ -32,20 +32,36 @@ The following changes addressing reviewer feedback were made:
 
 ## Test environments
 
-* Ubuntu 18.04, R 3.6.1
-* Ubuntu 16.04, R 3.5, R 3.6, devel
-* win-builder
+* macOS 10.15.1: R 3.6.1
+* Ubuntu 18.04: R 3.6.1
+* Travis Ubuntu 16.04: oldrelease, release, devel
+* win-builder: oldrelease, release, devel
+* rhub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
 
 ## R CMD check results
 
 There were no ERRORs or WARNINGs.
 
-Sometimes a NOTE about example running time > 5 seconds is produced; it is caused by the new slt_* examples.
+There was 1 NOTE:
+  * checking CRAN incoming feasibility ... NOTE
+    Maintainer: 'Alan Dipert <barret@rstudio.com>'
+
+    New submission
+
 
 ## Downstream dependencies
 
 There are currently no downstream dependencies of this package.
 
+
+
+
+
+
+
+
+
+-------------------------------------------------------------------------------
 # 2019-11-22 1.0.0
 
 This is the initial release of shinyloadtest to CRAN.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -38,7 +38,9 @@ The following changes addressing reviewer feedback were made:
 
 ## R CMD check results
 
-There were no ERRORs, WARNINGs, or NOTEs.
+There were no ERRORs or WARNINGs.
+
+Sometimes a NOTE about example running time is produced; it is caused by the slt_* examples suggested by CRAN review.
 
 ## Downstream dependencies
 

--- a/man/shinyloadtest_report.Rd
+++ b/man/shinyloadtest_report.Rd
@@ -36,8 +36,7 @@ shinyloadtest_report(
 Make shinyloadtest Report
 }
 \examples{
-  # Run best with example(shinyloadtest_report, ask = FALSE)
-  html_file <- sprintf("\%s.html", tempfile("report"))
-  message(sprintf("Generating report: \%s", html_file))
-  shinyloadtest_report(slt_demo_data_1, output = html_file)
+\dontrun{
+  shinyloadtest_report(slt_demo_data_1)
+}
 }

--- a/man/slt_plot.Rd
+++ b/man/slt_plot.Rd
@@ -76,7 +76,9 @@ Many different plotting routines to display different loadtest information.
 }}
 
 \examples{
-slt_time_boxplot(slt_demo_data_16)
+slt_session_duration(slt_demo_data_4)
+
+\donttest{slt_time_boxplot(slt_demo_data_16)
 slt_time_concurrency(slt_demo_data_16)
 slt_waterfall(slt_demo_data_16)
 slt_hist_loadtimes(slt_demo_data_16)
@@ -85,5 +87,5 @@ slt_session(slt_demo_data_16)
 slt_session_duration(slt_demo_data_16)
 slt_session_latency(slt_demo_data_16)
 slt_http_latency(slt_demo_data_16)
-slt_websocket_latency(slt_demo_data_16)
+slt_websocket_latency(slt_demo_data_16)}
 }

--- a/scripts/rhub.R
+++ b/scripts/rhub.R
@@ -1,0 +1,12 @@
+
+
+email <- NULL
+# email <- "barret@rstudio.com"
+
+check_output <- devtools::check_rhub(email = email, interactive = FALSE)
+
+for (i in seq_len(nrow(check_output$urls()))) {
+  check_output$livelog(i)
+}
+
+check_output$cran_summary()

--- a/scripts/rhub.R
+++ b/scripts/rhub.R
@@ -5,6 +5,7 @@ email <- NULL
 
 check_output <- devtools::check_rhub(email = email, interactive = FALSE)
 
+# check_output$web()
 for (i in seq_len(nrow(check_output$urls()))) {
   check_output$livelog(i)
 }

--- a/tests/testthat/test-report-gen.R
+++ b/tests/testthat/test-report-gen.R
@@ -1,7 +1,10 @@
 context("report generation")
 
 test_that("reports are generated", {
-  html_file <- sprintf("%s.html", tempfile("report"))
-  shinyloadtest_report(slt_demo_data_1, output = html_file, open_browser = FALSE)
-  expect_true(file.exists(html_file))
+  skip_on_cran()
+  expect_true({
+    html_file <- sprintf("%s.html", tempfile("report"))
+    shinyloadtest_report(slt_demo_data_1, output = html_file, open_browser = FALSE)
+    file.exists(html_file)
+  })
 })

--- a/tests/testthat/test-report-gen.R
+++ b/tests/testthat/test-report-gen.R
@@ -2,9 +2,7 @@ context("report generation")
 
 test_that("reports are generated", {
   skip_on_cran()
-  expect_true({
-    html_file <- sprintf("%s.html", tempfile("report"))
-    shinyloadtest_report(slt_demo_data_1, output = html_file, open_browser = FALSE)
-    file.exists(html_file)
-  })
+  html_file <- sprintf("%s.html", tempfile("report"))
+  shinyloadtest_report(slt_demo_data_1, output = html_file, open_browser = FALSE)
+  expect_true(file.exists(html_file))
 })

--- a/tests/testthat/test-report-gen.R
+++ b/tests/testthat/test-report-gen.R
@@ -1,0 +1,7 @@
+context("report generation")
+
+test_that("reports are generated", {
+  html_file <- sprintf("%s.html", tempfile("report"))
+  shinyloadtest_report(slt_demo_data_1, output = html_file, open_browser = FALSE)
+  expect_true(file.exists(html_file))
+})


### PR DESCRIPTION
This moves exercising `shinyloadtest_report()` from an `@examples` block over to a unit test.