### PR TITLE
as.tibble => as_tibble

### DIFF
--- a/R/analysis.R
+++ b/R/analysis.R
@@ -227,7 +227,7 @@ get_times <- function(df) {
               concurrency = mean(concurrency)) %>%
     ungroup() %>%
     arrange(input_line_number, run) %>%
-    tibble::as.tibble()
+    tibble::as_tibble()
 }
 
 


### PR DESCRIPTION
The current use of `as.tibble` prints a warning when we call `shinyloadtest::load_runs`: 

```
Warning message:
`as.tibble()` is deprecated as of tibble 2.0.0.
Please use `as_tibble()` instead.
The signature and semantics have changed, see `?as_tibble`.
This warning is displayed once every 8 hours.
Call `lifecycle::last_warnings()` to see where this warning was generated. 
```

This PR changes to as_tibble so that we don't have this message anymore.