### PR TITLE
Avoid causing libcurl to use chunked Transfer-Encoding

### DIFF
--- a/R/shiny-recorder.R
+++ b/R/shiny-recorder.R
@@ -308,6 +308,9 @@ RecordingSession <- R6::R6Class("RecordingSession",
         # TODO Figure out how to use CURL_INFILESIZE_LARGE to upload files
         # larger than 2GB.
         curl::handle_setopt(h, post = TRUE, infilesize = as.integer(req$HTTP_CONTENT_LENGTH))
+        # Provide total postfieldsize to libcurl so it does not activate chunked
+        # Transfer-Encoding.
+        curl::handle_setopt(h, postfieldsize = as.integer(req$HTTP_CONTENT_LENGTH))
         dataFileName <- sprintf("%s.post.%d", private$outputFileName, length(private$postFiles))
         writeCon <- file(dataFileName, "wb")
         curl::handle_setopt(h, readfunction = function(n) {


### PR DESCRIPTION
For #154 I had success by preventing the recorder proxy from employing chunked Transfer-Encoding. It seemed like connect et. al just don't do well when given properly formed chunked requests.

Here's someone driving libcurl with PHP who had a similar issue: https://github.com/php/php-src/issues/8165
Based on the age of that, I wonder if cURL going to chunked Transfer-Encoding when it is uploading from `CURLOPT_READFUNCTION` and the length hasn't been provided ahead of time is a newer behavior.

Disclaimer: I don't really write much R :upside_down_face: 