### PR TITLE
Use reframe instead of summarise

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -369,7 +369,7 @@ maintenance_vline <- function(data, type = c("time", "session")) {
   summary <- data %>%
     group_by(run) %>%
     filter(maintenance) %>%
-    summarise(
+    reframe(
       event = "Warm up / Cooldown",
       time = if (type == "time") {
         c(min(start), max(end))


### PR DESCRIPTION
Fixes #168: "Returning more (or less) than 1 row per summarise() group was deprecated in dplyr 1.1.0."

I tried `shinyloadtest_report` on a very simple run and the deprecation warning went away, while creating exactly the same HTML file as before the change.