### PR TITLE
More flexible grob navigation, works with newer ggplot2 versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     R6,
     curl,
     dplyr (>= 1.0.0),
-    ggplot2,
+    ggplot2 (>= 3.4.0),
     httpuv (>= 1.5.2),
     jsonlite,
     magrittr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed #168: Remove deprecated usage of `dplyr::summarise` during `shinyloadtest_report`.
 
+* Fixed #163: `gtable_trim` error during `shinyloadtest_report` with newer versions of ggplot2.
+
 ### Improvements
 
 

--- a/R/make_report.R
+++ b/R/make_report.R
@@ -382,18 +382,26 @@ save_svg <- function(p, output, width = 15, height = 10, units = "in", ...) {
 }
 
 
-extract_legend <- function(p) {
-  first_grob <- function(x) {
-    x$grobs[[1]]
+find_legend_grob <- function(gtbl) {
+  # Find the legend grob; tested on ggplot2 3.4.4 and 3.5.1, which have different grob layouts.
+  # On 3.4.4 it's guide-box > guides, on 3.5.1 it's guide-box-bottom > guides.
+
+  guide_box_grobs <- gtbl$grobs[grep("^guide-box", gtbl$layout$name)]
+  nonzero_grobs <- guide_box_grobs[!vapply(guide_box_grobs, inherits, logical(1), what = "zeroGrob")]
+  if (length(nonzero_grobs) != 1) {
+    stop("Couldn't find legend grob (searched for 'guide-box*')! Perhaps ggplot2's grob layout has changed?")
   }
+  guides <- gtable::gtable_filter(nonzero_grobs[[1]], "^guides$")
+  if (nrow(guides$layout) != 1) {
+    stop("Couldn't find legend grob (searched for 'guides')! Perhaps ggplot2's grob layout has changed?")
+  }
+  guides$grobs[[1]]
+}
+
+extract_legend <- function(p) {
   legend_grob <- ggplot2::ggplot_build(p) %>%
     ggplot2::ggplot_gtable() %>%
-    gtable::gtable_filter("guide-box") %>%
-    first_grob() %>%
-    gtable::gtable_filter("guides") %>%
-    first_grob()
-    # %>%
-    # gtable::gtable_filter("key|label")
+    find_legend_grob()
 
   list(
     legend_grob = legend_grob,

--- a/R/make_report.R
+++ b/R/make_report.R
@@ -388,12 +388,15 @@ find_legend_grob <- function(gtbl) {
 
   guide_box_grobs <- gtbl$grobs[grep("^guide-box", gtbl$layout$name)]
   nonzero_grobs <- guide_box_grobs[!vapply(guide_box_grobs, inherits, logical(1), what = "zeroGrob")]
-  if (length(nonzero_grobs) != 1) {
-    stop("Couldn't find legend grob (searched for 'guide-box*')! Perhaps ggplot2's grob layout has changed?")
+  if (length(nonzero_grobs) == 0) {
+    return(ggplot2::zeroGrob())
+  }
+  if (length(nonzero_grobs) > 1) {
+    warn("Found legends at multiple positions. Picking the first legend.")
   }
   guides <- gtable::gtable_filter(nonzero_grobs[[1]], "^guides$")
-  if (nrow(guides$layout) != 1) {
-    stop("Couldn't find legend grob (searched for 'guides')! Perhaps ggplot2's grob layout has changed?")
+  if (nrow(guides$layout) > 1) {
+    warn("Found multiple legends. Picking the first legend.")
   }
   guides$grobs[[1]]
 }

--- a/R/make_report.R
+++ b/R/make_report.R
@@ -394,11 +394,7 @@ find_legend_grob <- function(gtbl) {
   if (length(nonzero_grobs) > 1) {
     warn("Found legends at multiple positions. Picking the first legend.")
   }
-  guides <- gtable::gtable_filter(nonzero_grobs[[1]], "^guides$")
-  if (nrow(guides$layout) > 1) {
-    warn("Found multiple legends. Picking the first legend.")
-  }
-  guides$grobs[[1]]
+  gtable::gtable_filter(nonzero_grobs[[1]], "^guides$")
 }
 
 extract_legend <- function(p) {

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -100,7 +100,7 @@ slt_waterfall <- function(df, limits = NULL) {
     mutate(label = fct_rev(str_trunc(label, 50)))
 
   ggplot(df1, aes(end, label, group = session_id, color = concurrency)) +
-    geom_line(size = 0.5) +
+    geom_line(linewidth = 0.5) +
     maintenance_vline(df1, "time") +
     scale_colour_gradientn(
       colours = c("#413554", "#75aadb", "#9efa9e", "#fdc086"),
@@ -381,7 +381,7 @@ maintenance_vline <- function(data, type = c("time", "session")) {
   geom_vline(
     aes(xintercept = time),
     data = summary,
-    size = 0.5,
+    linewidth = 0.5,
     linetype = "dashed",
     colour = alpha("black", 0.70)
   )

--- a/tests/testthat/test-report-gen.R
+++ b/tests/testthat/test-report-gen.R
@@ -6,3 +6,12 @@ test_that("reports are generated", {
   shinyloadtest_report(slt_demo_data_1, output = html_file, open_browser = FALSE)
   expect_true(file.exists(html_file))
 })
+
+test_that("legend extraction works", {
+  df <- data.frame(x = 1:3, y = 1:3, c = LETTERS[1:3], stringsAsFactors = FALSE)
+  p <- ggplot2::ggplot(df, ggplot2::aes(x = x, y = y, color = c)) +
+    ggplot2::geom_point() +
+    ggplot2::theme(legend.position = "bottom") +
+    ggplot2::labs(fill = "", color = "")
+  extract_legend(p)
+})


### PR DESCRIPTION
Fixes both #163 and #165.

It looks like we go digging around in ggplot2's gtable, looking for the legend, so we can make an SVG out of it. Sometime between ggplot2 3.4.4 and 3.5.1, the layout of that table changed; previously there was a `guide-box` entry, and now there are `guide-box-[top|left|right|bottom]`, only one of which (`bottom`) appears to be non-empty in this code path.

I've added a new `find_legend_grob` function that handles both scenarios.

## TODO

- [ ] Unit test so maintainers can know if this happens again